### PR TITLE
Allow inverted affiliations in roles

### DIFF
--- a/src/Repositories/Character/CharacterRepository.php
+++ b/src/Repositories/Character/CharacterRepository.php
@@ -106,10 +106,23 @@ trait CharacterRepository
 
                 // If the user has any affiliations and can
                 // list those characters, add them
-                if ($user->has('character.list', false))
+                if ($user->has('character.list', false)) {
+                    $map = $user->getAffiliationMap();
+                
                     $query = $query->whereIn('account_api_key_info_characters.characterID',
-                        array_keys($user->getAffiliationMap()['char']));
-
+                        $this->getAffiliationsFromMap($map['char'], 'character.list'));
+                        
+                    
+                    // If there are any roles with inverted affiliations in the map 
+                    // go through these
+                    foreach ($map['inverted'] as $key => $invertedRole) {
+                        if (in_array('character.list', $invertedRole['permissions'])) {
+                            $query->orWhereNotIn('account_api_key_info_characters.characterID', $invertedRole['char']);
+                        }   
+                    }
+                }
+                
+                
                 // Add any characters from owner API keys
                 $query->orWhere('eve_api_keys.user_id', $user->id);
             });
@@ -247,10 +260,20 @@ trait CharacterRepository
 
                 // If the user has any affiliations and can
                 // list those characters, add them
-                if ($user->has('character.list', false))
+                if ($user->has('character.list', false)) {
+                    $map = $user->getAffiliationMap();
+                
                     $query = $query->whereIn('characterID',
-                        array_keys($user->getAffiliationMap()['char']));
-
+                        $this->getAffiliationsFromMap($map['char'], 'character.list'));
+                        
+                    // If there are any roles with inverted affiliations in the map 
+                    // go through these
+                    foreach ($map['inverted'] as $key => $invertedRole) {
+                        if (in_array('character.list', $invertedRole['permissions'])) {
+                            $query->orWhereNotIn('characterID', $invertedRole['char']);
+                        }   
+                    }
+                }
                 // Add any characters from owner API keys
                 $query->orWhere('eve_api_keys.user_id', $user->id);
             });
@@ -804,9 +827,20 @@ trait CharacterRepository
 
                 // If the user has any affiliations and can
                 // list those characters, add them
-                if ($user->has('character.mail', false))
+                if ($user->has('character.mail', false)) {
+                    $map = $user->getAffiliationMap();
+                
                     $query = $query->whereIn('account_api_key_info_characters.characterID',
-                        array_keys($user->getAffiliationMap()['char']));
+                        $this->getAffiliationsFromMap($map['char'], 'character.mail'));           
+                        
+                    // If there are any roles with inverted affiliations in the map 
+                    // go through these
+                    foreach ($map['inverted'] as $key => $invertedRole) {
+                        if (in_array('character.mail', $invertedRole['permissions'])) {
+                            $query->orWhereNotIn('account_api_key_info_characters.characterID', $invertedRole['char']);
+                        }   
+                    }             
+                }
 
                 // Add any characters from owner API keys
                 $query->orWhere('eve_api_keys.user_id', $user->id);
@@ -904,6 +938,25 @@ trait CharacterRepository
 
         return UpcomingCalendarEvent::where('characterID', $character_id)
             ->get();
+    }
+    
+    /**
+    * Return array of affiliations that contains the specified permission
+    * 
+    * @param $map
+    * @param $permission
+    *
+    * $return array
+    */    
+    private function getAffiliationsFromMap($map, $permission) {
+        $results = array();
+        
+        foreach($map as $affiliation => $permissions) {
+            if (in_array($permission, $permissions))
+                $results[] = $affiliation;
+        }
+        
+        return $results;
     }
 
 }


### PR DESCRIPTION
This accompanies PR 22 in the Web repository.

Uses the inverted affiliation maps when these are selected.

Also changes the queries in the corps and members listings so that only characters/corps affiliated with roles that has the 'character.list' permission set will cause characters to be listed.
