### PR TITLE
Prevent SQL query issue with user having character.list permission

### DIFF
--- a/src/Repositories/Character/CharacterRepository.php
+++ b/src/Repositories/Character/CharacterRepository.php
@@ -195,7 +195,7 @@ trait CharacterRepository
                 // If the user has any affiliations and can
                 // list those characters, add them
                 if ($user->has('character.list', false))
-                    $query = $query->whereIn('characterID',
+                    $query = $query->whereIn('account_api_key_info_characters.characterID',
                         array_keys($user->getAffiliationMap()['char']));
 
                 // Add any characters from owner API keys


### PR DESCRIPTION
This hotfix prevent SQL query issue due to the fact the characterID field is available in account_api_key_info_characters and eve_character_infos.
