### PR TITLE
migrate standings helper to new ESI models

### DIFF
--- a/src/Repositories/Character/Standings.php
+++ b/src/Repositories/Character/Standings.php
@@ -23,7 +23,7 @@
 namespace Seat\Services\Repositories\Character;
 
 use Illuminate\Support\Collection;
-use Seat\Eveapi\Models\Character\Standing;
+use Seat\Eveapi\Models\Character\CharacterStanding;
 
 /**
  * Class Standings.
@@ -41,7 +41,9 @@ trait Standings
     public function getCharacterStandings(int $character_id): Collection
     {
 
-        return Standing::where('characterID', $character_id)
+        return CharacterStanding::where('character_id', $character_id)
+            ->leftJoin('chrFactions', 'from_id', '=', 'factionID')
+            ->orderBy('from_type')
             ->get();
     }
 }


### PR DESCRIPTION
depends on eveseat/web#100 and eveseat/resources#3