### PR TITLE
fix(corporation assets): Fix asset top level listing

### DIFF
--- a/src/Repositories/Corporation/Assets.php
+++ b/src/Repositories/Corporation/Assets.php
@@ -84,7 +84,6 @@ trait Assets
             ->whereIn('location_flag', [
                 // These locations look like they are top-level. Even though 'OfficeFolder' is
                 // top level, lets just flatten it anyways.
-                'CorpSAG1', 'CorpSAG2', 'CorpSAG3', 'CorpSAG4', 'CorpSAG5', 'CorpSAG6', 'CorpSAG7',
                 'AssetSafety', 'OfficeFolder', 'Impounded', 'CorpDeliveries',
             ])
             ->where('corporation_assets.corporation_id', $corporation_id)


### PR DESCRIPTION
It appears we're using divisions as top level which are not. Division are always inside
OfficeFolder entry which is a Custom Office. It implies wrong name resolving for structures.

Closes eveseat/seat#337