### PR TITLE
Alter historical price table columns:

### DIFF
--- a/src/database/migrations/2018_10_05_064533_alter_historical_prices_columns.php
+++ b/src/database/migrations/2018_10_05_064533_alter_historical_prices_columns.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterHistoricalPricesColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        Schema::table('historical_prices', function (Blueprint $table) {
+
+            $table->decimal('average_price', 30, 2)->default(0.0)->change();
+            $table->decimal('adjusted_price', 30, 2)->default(0.0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+        Schema::table('historical_prices', function (Blueprint $table) {
+
+            $table->decimal('average_price')->change();
+            $table->decimal('adjusted_price')->change();
+        });
+    }
+}

--- a/src/database/migrations/2018_10_05_064533_alter_historical_prices_columns.php
+++ b/src/database/migrations/2018_10_05_064533_alter_historical_prices_columns.php
@@ -1,8 +1,28 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015, 2016, 2017, 2018  Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AlterHistoricalPricesColumns extends Migration
 {


### PR DESCRIPTION
* `average_price` from precision 10 to precision 32 with a scale of 2
* `adjusted_price` from precision 10 to precision 32 with a scale of 2

This change is needed to support prices which needs a higher precision and would resolve: https://github.com/eveseat/seat/issues/451#issuecomment-427259236 

This error is absolutely my causing and i want to apologize for this. I should have copied the migration behavior of `market_prices` instead.
https://github.com/eveseat/eveapi/blob/master/src/database/migrations/2017_12_01_000000_create_market_prices_table.php#L40-L41