### PR TITLE
BUGFIX: when looking in a list of ids..

### DIFF
--- a/src/Search/Search.php
+++ b/src/Search/Search.php
@@ -167,7 +167,7 @@ trait Search
                 // Add any characters from owner API keys
                 $user_character_ids = auth()->user()->group->users->pluck('id')->toArray();
 
-                $query->orWhere('character_assets.character_id', $user_character_ids);
+                $query->orWhereIn('character_assets.character_id', $user_character_ids);
             });
         }
 


### PR DESCRIPTION
one should use IN..

Bug: 
When using the search as a user with affiliations for all corps and all chars, the search ended up not showing any results, while as a superuser they did. 
a closer look at the query involved, and how it is build showed that it was doing a orWhere with a field name and an array. When checking if a fields value is within an array the use of orWhereIn  is required, to ensure the array is treated as a list for an IN check, rather than as a string/int value for a comparison.

this is also in line with how similar queries are build in other parts of the search.