### PR TITLE
Update Corporation Members repository to use updated model relations

### DIFF
--- a/src/Repositories/Corporation/Members.php
+++ b/src/Repositories/Corporation/Members.php
@@ -42,10 +42,13 @@ trait Members
     {
 
         return CorporationMemberTracking::with(
-            'user',
-            'user.refresh_token',
-            'type'
+            'refresh_token',
+            'refresh_token.user',
+            'refresh_token.user.main_character',
+            'ship',
+            'character'
             )
+            ->select('corporation_member_trackings.*')
             ->where('corporation_id', $corporation_id);
 
     }


### PR DESCRIPTION
Related to https://github.com/eveseat/eveapi/pull/197 and https://github.com/eveseat/web/pull/386.

Updated the Members repository to use the RefreshToken relation instead of user, but to also eager load the User model via RefreshToken, the users main character (so we can group the related characters together in DataTables), character name (for sorting/filtering purposes) from UniverseNames and the ship type (added separate column to enable searching, was previously included in the view for the Location column).