### PR TITLE
enhance sso: ability to define scope profiles

### DIFF
--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -155,13 +155,7 @@ class Provider extends AbstractProvider
      */
     private function validateJwtToken(string $access_token): array
     {
-        $scopes = [];
-
-        try {
-            $scopes = setting('sso_scopes', true);
-        } catch (SettingException $e) {
-            logger()->error($e->getMessage(), $e->getTrace());
-        }
+        $scopes = session()->pull('scopes', []);
 
         // pulling JWK sets from CCP
         $sets = $this->getJwkSets();

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -25,7 +25,6 @@ namespace Seat\Services\Socialite\EveOnline;
 use Jose\Component\Core\JWKSet;
 use Jose\Easy\Load;
 use Seat\Services\Exceptions\EveImageException;
-use Seat\Services\Exceptions\SettingException;
 use Seat\Services\Image\Eve;
 use Seat\Services\Socialite\EveOnline\Checker\Claim\AzpChecker;
 use Seat\Services\Socialite\EveOnline\Checker\Claim\NameChecker;

--- a/src/database/migrations/2020_04_27_231132_convert_sso_scopes_to_list.php
+++ b/src/database/migrations/2020_04_27_231132_convert_sso_scopes_to_list.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class ConvertSsoScopesToList extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        $sso_scopes = DB::table('global_settings')
+            ->where('name', 'sso_scopes')
+            ->first();
+
+        $new_sso_scopes = [
+            [
+                'name'    => 'default',
+                'scopes'  => json_decode($sso_scopes->value),
+                'default' => true,
+            ]
+        ];
+
+        DB::table('global_settings')
+            ->where('name', 'sso_scopes')
+            ->update(['value' => json_encode($new_sso_scopes)]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+        $sso_scopes = DB::table('global_settings')
+            ->where('name', 'sso_scopes')
+            ->first();
+
+        if(! is_null($sso_scopes)) {
+            $sso_scopes = json_decode($sso_scopes->value);
+            $old_sso_scopes = [];
+            foreach($sso_scopes as $scope) {
+                if ($scope->default == true) {
+                    $old_sso_scopes = $scope->scopes;
+                }
+            }
+
+            DB::table('global_settings')
+                ->where('name', 'sso_scopes')
+                ->update(['value' => $old_sso_scopes]);
+        }
+    }
+}

--- a/src/database/migrations/2020_04_27_231132_convert_sso_scopes_to_list.php
+++ b/src/database/migrations/2020_04_27_231132_convert_sso_scopes_to_list.php
@@ -21,9 +21,7 @@
  */
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 class ConvertSsoScopesToList extends Migration
 {
@@ -44,7 +42,7 @@ class ConvertSsoScopesToList extends Migration
                 'name'    => 'default',
                 'scopes'  => json_decode($sso_scopes->value),
                 'default' => true,
-            ]
+            ],
         ];
 
         DB::table('global_settings')

--- a/src/database/migrations/2020_04_27_231132_convert_sso_scopes_to_list.php
+++ b/src/database/migrations/2020_04_27_231132_convert_sso_scopes_to_list.php
@@ -39,6 +39,7 @@ class ConvertSsoScopesToList extends Migration
 
         $new_sso_scopes = [
             [
+                'id'      => 0,
                 'name'    => 'default',
                 'scopes'  => json_decode($sso_scopes->value),
                 'default' => true,


### PR DESCRIPTION
This PR supports PR eveseat/web#424 and allows the JwtToken verification to read the scopes from the session that have been set by the SsoController in eveseat/web instead of the value saved in the settings table, as the scopes may vary depending upon which profile was passed to the SsoController.