### PR TITLE
feat(sde): explode map into specific entities

### DIFF
--- a/src/Repositories/Character/MiningLedger.php
+++ b/src/Repositories/Character/MiningLedger.php
@@ -42,7 +42,7 @@ trait MiningLedger
     public function getCharacterLedger(Collection $character_ids): Builder
     {
 
-        return CharacterMining::with('type', 'system')
+        return CharacterMining::with('type', 'solar_system')
             ->select(
                 'character_minings.date',
                 'character_minings.character_id',

--- a/src/Repositories/Corporation/Extractions.php
+++ b/src/Repositories/Corporation/Extractions.php
@@ -38,7 +38,7 @@ trait Extractions
     {
         // retrieve any valid extraction for the current corporation
         return CorporationIndustryMiningExtraction::with(
-            'moon', 'moon.system', 'moon.constellation', 'moon.region', 'moon.moon_content',
+            'moon', 'moon.solar_system', 'moon.constellation', 'moon.region', 'moon.content',
             'structure', 'structure.info', 'structure.services')
             ->where('corporation_id', $corporation_id)
             ->where('natural_decay_time', '>', carbon()->subSeconds(CorporationIndustryMiningExtraction::THEORETICAL_DEPLETION_COUNTDOWN))

--- a/src/Repositories/Corporation/Structures.php
+++ b/src/Repositories/Corporation/Structures.php
@@ -38,7 +38,7 @@ trait Structures
     public function getCorporationStructures(int $corporation_id)
     {
 
-        return CorporationStructure::with('services', 'type', 'system')
+        return CorporationStructure::with('services', 'type', 'solar_system')
             ->where('corporation_id', $corporation_id)
             ->get();
     }


### PR DESCRIPTION
eloquent does not like internal relation - and generated query can sometimes lead to error (ie: to be able to sort)

this is splitting the mapDenormalize table into 6 specifics sub-tables (most used) :
 - regions
 - constellations
 - systems
 - stars
 - planets
 - moons