### PR TITLE
feat: improve telemetry and use a more suitable tool than google-analytics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "composer/semver": "^2.0",
     "doctrine/dbal": "^2.9",
     "guzzlehttp/guzzle": "^6.3",
+    "influxdata/influxdb-client-php": "^1.9",
     "laravel/framework": "^6.2",
     "web-token/jwt-easy": "^2.1",
     "web-token/jwt-signature-algorithm-hmac": "^2.1",

--- a/src/Config/services.config.php
+++ b/src/Config/services.config.php
@@ -21,7 +21,12 @@
  */
 
 return [
-
-    'version' => '4.1.0',
-
+    'telemetry' => [
+        'influxdb' => [
+            'url'          => 'https://stats.eveseat.net',
+            'token'        => 'fGAgOsrHKM7LOe0aBPBFyS0tlwZfZp8-jwZo3FFxBZl-Mdfoz3hvabkIdLoBzh4m05UchNVn34tG_s5DqnquEg==',
+            'bucket'       => 'seat',
+            'organization' => 'eveseat.net',
+        ],
+    ],
 ];

--- a/src/Traits/Telemeter.php
+++ b/src/Traits/Telemeter.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Services\Traits;
+
+use Exception;
+use InfluxDB2\Client;
+use InfluxDB2\Model\WritePrecision;
+
+/**
+ * Trait Telemeter
+ *
+ * @package Seat\Eveapi\Traits
+ */
+trait Telemeter
+{
+    use VersionsManagementTrait;
+
+    /**
+     * @var \InfluxDB2\Client
+     */
+    private static $metrics_client;
+
+    /**
+     * @param string $endpoint
+     * @param int $status
+     *
+     * @throws \Seat\Services\Exceptions\SettingException
+     */
+    public function sendEsiMetric(string $endpoint, int $status)
+    {
+        $this->sendTelemetryData([
+            'name'   => 'esi',
+            'tags'   => ['status' => $status, 'endpoint' => $endpoint],
+            'fields' => ['value' => 1],
+            'time'   => now()->timestamp,
+        ]);
+    }
+
+    /**
+     * @param int $tokens
+     * @param int $characters
+     * @param int $corporations
+     *
+     * @example FluxDB usage
+     *
+     * from(bucket: "seat")
+     * |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+     * |> filter(fn: (r) => r["_measurement"] == "load")
+     * |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+     * |> yield(name: "mean")
+     */
+    public function sendLoadMetrics(int $tokens, int $characters, int $corporations)
+    {
+        $this->sendTelemetryData([
+            'name' => 'load',
+            'fields' => [
+                'tokens' => $tokens,
+                'characters' => $characters,
+                'corporations' => $corporations,
+            ],
+            'time' => now()->timestamp,
+        ]);
+    }
+
+    /**
+     * @throws \Seat\Services\Exceptions\SettingException
+     *
+     * @example FluxDB usage
+     *
+     * from(bucket: "seat")
+     * |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+     * |> filter(fn: (r) => r._measurement == "environment")
+     * |> filter(fn: (r) => r._field == "api")
+     * |> group(columns: ["_value"])
+     * |> map(fn: (r) => ({_time: r._time, _value: r._value, _field: r._field, index:1}))
+     * |> cumulativeSum(columns: ["index"])
+     * |> last()
+     */
+    public function sendEnvironmentMetrics()
+    {
+        $versions = $this->getPluginsMetadataList()->core->mapWithKeys(function ($package) {
+            return [
+                $package->getPackagistPackageName() => $package->getVersion(),
+            ];
+        });
+
+        $this->sendTelemetryData([
+            'name' => 'environment',
+            'fields' => array_merge([
+                'php' => phpversion(),
+                'os' => sprintf('%s/%s', php_uname('s'), php_uname('r')),
+            ], $versions->toArray()),
+            'time' => now()->timestamp,
+        ]);
+    }
+
+    /**
+     * @param array $data
+     */
+    private function sendTelemetryData(array $data)
+    {
+        // prevent telemetry data to be sent when tracking is disabled.
+        if (setting('allow_tracking', true) === 'no')
+            return;
+
+        $client = $this->getMetricsClient();
+
+        try {
+            $stream = $client->createWriteApi();
+            $stream->write($data);
+        } catch (Exception $exception) {
+            logger()->warning('Unable to send telemetry data.', [
+                'code' => $exception->getCode(),
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return \InfluxDB2\Client
+     */
+    private function getMetricsClient()
+    {
+        if (! is_null(self::$metrics_client))
+            return self::$metrics_client;
+
+        self::$metrics_client = new Client([
+            'url'       => config('services.config.telemetry.influxdb.url'),
+            'token'     => config('services.config.telemetry.influxdb.token'),
+            'bucket'    => config('services.config.telemetry.influxdb.bucket'),
+            'org'       => config('services.config.telemetry.influxdb.organization'),
+            'precision' => WritePrecision::S,
+            'tags' => [
+                'instance' => $this->getTelemetryInstanceID(),
+            ],
+        ]);
+
+        return self::$metrics_client;
+    }
+
+    /**
+     * Return the telemetry instance ID.
+     *
+     * @return string
+     * @throws \Seat\Services\Exceptions\SettingException
+     */
+    private function getTelemetryInstanceID()
+    {
+        $id = setting('analytics_id', true);
+
+        if (! $id) {
+
+            // Generate a V4 random UUID
+            //  https://gist.github.com/dahnielson/508447#file-uuid-php-L74
+            $id = sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+                mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+                mt_rand(0, 0xffff),
+                mt_rand(0, 0x0fff) | 0x4000,
+                mt_rand(0, 0x3fff) | 0x8000,
+                mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+            );
+
+            // Set the generated UUID in the applications config
+            setting(['analytics_id', $id], true);
+        }
+
+        return $id;
+    }
+}


### PR DESCRIPTION
telemetry is still an optional thing and can be disabled into settings
the list of collected data is the following :
- instance unique ID
- amount of valid refresh tokens
- amount of character sheet
- amount of corporation sheet
- used php version
- used operating system
- installed SeAT packages and related versions
- called endpoint mask and http response status

Used in scheduled commands, those information can help to determine :
 - ESI load on behalf on SeAT instances
 - SeAT instances average load
 - Updates distributions

![image](https://user-images.githubusercontent.com/648753/103352169-c334aa80-4aa5-11eb-850d-d17294e11c6f.png)
![image](https://user-images.githubusercontent.com/648753/103352170-c62f9b00-4aa5-11eb-85ca-eae298a34d4e.png)
![image](https://user-images.githubusercontent.com/648753/103352175-c891f500-4aa5-11eb-9608-003cd568052e.png)
