### PR TITLE
Reduce coupling with eseye

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,8 @@
     "doctrine/dbal": "^3.0",
     "guzzlehttp/guzzle": "^7.0",
     "laravel/framework": "^9.0",
+    "psr/simple-cache": "^1.0|^2.0|^3.0",
+    "psr/log": "^1.0|^2.0|^3.0",
     "web-token/jwt-easy": "^2.1",
     "web-token/jwt-signature-algorithm-hmac": "^2.1",
     "web-token/jwt-signature-algorithm-rsa": "^2.1",

--- a/src/Contracts/EsiClient.php
+++ b/src/Contracts/EsiClient.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2022 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Services\Contracts;
+
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
+
+interface EsiClient
+{
+    /**
+     * @return \Seat\Services\Contracts\EsiToken
+     */
+    public function getAuthentication(): EsiToken;
+
+    /**
+     * @param  \Seat\Services\Contracts\EsiToken  $authentication
+     * @return $this
+     */
+    public function setAuthentication(EsiToken $authentication): self;
+
+    /**
+     * @return bool
+     */
+    public function isAuthenticated(): bool;
+
+    /**
+     * @return string
+     */
+    public function getVersion(): string;
+
+    /**
+     * @param  string  $version
+     * @return $this
+     */
+    public function setVersion(string $version): self;
+
+    /**
+     * @return array
+     */
+    public function getQueryString(): array;
+
+    /**
+     * @param  array  $query
+     * @return $this
+     */
+    public function setQueryString(array $query): self;
+
+    /**
+     * @return array
+     */
+    public function getBody(): array;
+
+    /**
+     * @param  array  $body
+     * @return $this
+     */
+    public function setBody(array $body): self;
+
+    /**
+     * @param  string  $method
+     * @param  string  $uri
+     * @param  array  $uri_data
+     * @return \Seat\Services\Contracts\EsiResponse
+     */
+    public function invoke(string $method, string $uri, array $uri_data = []): EsiResponse;
+
+    /**
+     * @param  int  $page
+     * @return $this
+     */
+    public function page(int $page): self;
+
+    /**
+     * @return \Psr\Log\LoggerInterface
+     */
+    public function getLogger(): LoggerInterface;
+
+    /**
+     * @return \Psr\SimpleCache\CacheInterface
+     */
+    public function getCache(): CacheInterface;
+}

--- a/src/Contracts/EsiResponse.php
+++ b/src/Contracts/EsiResponse.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2022 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Services\Contracts;
+
+interface EsiResponse
+{
+    /**
+     * @return array
+     */
+    public function getHeaders(): array;
+
+    /**
+     * @param  string  $name
+     * @return array
+     */
+    public function getHeader(string $name): array;
+
+    /**
+     * @param  string  $name
+     * @return string
+     */
+    public function getHeaderLine(string $name): string;
+
+    /**
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasHeader(string $name): bool;
+
+    /**
+     * @return bool
+     */
+    public function expired(): bool;
+
+    /**
+     * @return int|null
+     */
+    public function getPagesCount(): ?int;
+
+    /**
+     * @return int
+     */
+    public function getStatusCode(): int;
+
+    /**
+     * @return bool
+     */
+    public function isFailed(): bool;
+
+    /**
+     * @return object|array
+     */
+    public function getBody(): object|array;
+
+    /**
+     * @return string
+     */
+    public function error(): string;
+
+    /**
+     * @return bool
+     */
+    public function isFromCache(): bool;
+}

--- a/src/Contracts/EsiToken.php
+++ b/src/Contracts/EsiToken.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2022 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Services\Contracts;
+
+interface EsiToken
+{
+    /**
+     * @return string
+     */
+    public function getAccessToken(): string;
+
+    /**
+     * @param  string  $token
+     * @return \Seat\Services\Contracts\EsiToken
+     */
+    public function setAccessToken(string $token): self;
+
+    /**
+     * @return string
+     */
+    public function getRefreshToken(): string;
+
+    /**
+     * @param  string  $token
+     * @return \Seat\Services\Contracts\EsiToken
+     */
+    public function setRefreshToken(string $token): self;
+
+    /**
+     * @return \DateTime
+     */
+    public function getExpiresOn(): \DateTime;
+
+    /**
+     * @param  \DateTime  $expires
+     * @return \Seat\Services\Contracts\EsiToken
+     */
+    public function setExpiresOn(\DateTime $expires): self;
+
+    /**
+     * @return array
+     */
+    public function getScopes(): array;
+
+    /**
+     * @param  string  $scope
+     * @return bool
+     */
+    public function hasScope(string $scope): bool;
+
+    /**
+     * @return bool
+     */
+    public function isExpired(): bool;
+}

--- a/src/Helpers/AnalyticsContainer.php
+++ b/src/Helpers/AnalyticsContainer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2021 Leon Jacobs
+ * Copyright (C) 2015 to 2022 Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ use ArrayAccess;
  * Acts as a data store for a Google Analytics Hit.
  *
  * Class AnalyticsContainer
+ *
  * @package Seat\Services\Helpers
  */
 class AnalyticsContainer implements ArrayAccess
@@ -53,8 +54,7 @@ class AnalyticsContainer implements ArrayAccess
     ];
 
     /**
-     * @param mixed $offset
-     *
+     * @param  mixed  $offset
      * @return bool
      */
     public function offsetExists(mixed $offset): bool
@@ -64,8 +64,7 @@ class AnalyticsContainer implements ArrayAccess
     }
 
     /**
-     * @param mixed $offset
-     *
+     * @param  mixed  $offset
      * @return mixed
      */
     public function offsetGet(mixed $offset): mixed
@@ -75,8 +74,8 @@ class AnalyticsContainer implements ArrayAccess
     }
 
     /**
-     * @param mixed $offset
-     * @param mixed $value
+     * @param  mixed  $offset
+     * @param  mixed  $value
      */
     public function offsetSet(mixed $offset, mixed $value): void
     {
@@ -85,7 +84,7 @@ class AnalyticsContainer implements ArrayAccess
     }
 
     /**
-     * @param mixed $offset
+     * @param  mixed  $offset
      */
     public function offsetUnset(mixed $offset): void
     {
@@ -95,7 +94,6 @@ class AnalyticsContainer implements ArrayAccess
 
     /**
      * @param $key
-     *
      * @return mixed
      */
     public function __get($key)
@@ -117,7 +115,6 @@ class AnalyticsContainer implements ArrayAccess
     /**
      * @param $key
      * @param $val
-     *
      * @return $this
      */
     public function set($key, $val): self

--- a/src/Helpers/AnalyticsContainer.php
+++ b/src/Helpers/AnalyticsContainer.php
@@ -57,7 +57,7 @@ class AnalyticsContainer implements ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
 
         return array_key_exists($offset, $this->data);
@@ -68,7 +68,7 @@ class AnalyticsContainer implements ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
 
         return $this->data[$offset];
@@ -78,7 +78,7 @@ class AnalyticsContainer implements ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
 
         $this->data[$offset] = $value;
@@ -87,7 +87,7 @@ class AnalyticsContainer implements ArrayAccess
     /**
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
 
         unset($this->data[$offset]);
@@ -120,7 +120,7 @@ class AnalyticsContainer implements ArrayAccess
      *
      * @return $this
      */
-    public function set($key, $val)
+    public function set($key, $val): self
     {
 
         $this->__set($key, $val);


### PR DESCRIPTION
Purpose of this is to provide a way to reduce coupling between SeAT and Eseye.

As a result, this PR is introducing 3 new contracts:

- EsiClient : which must be implemented by a package which want to provide ESI consuming service (ie: Eseye)
- EsiResponse : which must be implemented by a package which want to provide ESI consuming service (ie: Eseye)
- EsiToken: which must be implemented by a package which want to handle token (ie: Eseye)

In order to prevent eseye to be dependent of that package, idea is to provide a new package to provide Eseye within SeAT and which will implement those contracts.

However, I'm still unsure about the way to take regarding token.

In my opinion, client and response **MUST** be implemented by the same package.
However, I don't think the same package **HAVE TO** implement the token ability.