### PR TITLE
Fix ccp richtext parsing

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,9 @@
     <testsuite name="Report Parser Test Suite">
       <directory>./tests/ReportParser</directory>
     </testsuite>
+    <testsuite name="CCP HTML CLeaning Test Suite">
+      <directory>./tests/CleanCCPHtml</directory>
+    </testsuite>
   </testsuites>
   <source>
     <include>

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@ if (! function_exists('human_diff')) {
      * Return the time difference from now in a
      * format that humans can read.
      *
-     * @param $time
+     * @param  $time
      * @return string
      */
     function human_diff($time)
@@ -84,8 +84,8 @@ if (! function_exists('number')) {
     /**
      * Return a formatted number.
      *
-     * @param $number
-     * @param $dec
+     * @param  $number
+     * @param  $dec
      * @return string
      *
      * @throws \Seat\Services\Exceptions\SettingException
@@ -104,7 +104,7 @@ if (! function_exists('number_metric')) {
      * Return a shortened number with a suffix.
      * Depends on php5-intl.
      *
-     * @param $number
+     * @param  $number
      * @return bool|string
      */
     function number_metric($number)
@@ -130,7 +130,6 @@ if (! function_exists('clean_ccp_html')) {
 
         // CCP's rich text might be encapsulated in u'<content>'. Remove the u'
         $html = preg_match("/u'(.*)'/", $html, $match) ? $match[1] : $html;
-
 
         // handle escaped UTF-8 data
         // taken from https://stackoverflow.com/questions/2934563/how-to-decode-unicode-escape-sequences-like-u00ed-to-proper-utf-8-encoded-cha
@@ -169,7 +168,7 @@ if (! function_exists('evemail_threads')) {
      * Attempt to 'thread' evemails based on the separator
      * that is automatically added using the eve client.
      *
-     * @param $message
+     * @param  $message
      * @return \Illuminate\Support\Collection
      */
     function evemail_threads($message)

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -128,6 +128,16 @@ if (! function_exists('clean_ccp_html')) {
         if (empty($html))
             return '';
 
+        // CCP's rich text might be encapsulated in u'<content>'. Remove the u'
+        $html = preg_match("/u'(.*)'/", $html, $match) ? $match[1] : $html;
+
+
+        // handle escaped UTF-8 data
+        // taken from https://stackoverflow.com/questions/2934563/how-to-decode-unicode-escape-sequences-like-u00ed-to-proper-utf-8-encoded-cha
+        $html = preg_replace_callback('/\\\\u([0-9a-fA-F]{4})/', function ($match) {
+            return mb_convert_encoding(pack('H*', $match[1]), 'UTF-8', 'UTF-16BE');
+        }, $html);
+
         // Handle Unicode cases.
         $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
 

--- a/tests/CleanCCPHtml/CleanCCPHtmlTest.php
+++ b/tests/CleanCCPHtml/CleanCCPHtmlTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Seat\Tests\Services\CleanCCPHtml;
+
+use PHPUnit\Framework\TestCase;
+
+class CleanCCPHtmlTest extends TestCase
+{
+    public function testEncapsulationRemoval(){
+        $this->assertEquals('test',clean_ccp_html("u'test"));
+    }
+
+    public function testWithoutEncapsulation(){
+        $this->assertEquals('test',clean_ccp_html('test'));
+        //also test that the other feature continue to work
+        $this->assertEquals('test',clean_ccp_html('<xyz>test</xyz>'));
+    }
+
+    public function testEscapedUnicodeDecoding(){
+        $this->assertEquals('&#21019; &auml; &#128512;',clean_ccp_html('\u521b ä 😀'));
+    }
+}

--- a/tests/CleanCCPHtml/CleanCCPHtmlTest.php
+++ b/tests/CleanCCPHtml/CleanCCPHtmlTest.php
@@ -6,17 +6,20 @@ use PHPUnit\Framework\TestCase;
 
 class CleanCCPHtmlTest extends TestCase
 {
-    public function testEncapsulationRemoval(){
-        $this->assertEquals('test',clean_ccp_html("u'test'"));
+    public function testEncapsulationRemoval()
+    {
+        $this->assertEquals('test', clean_ccp_html("u'test'"));
     }
 
-    public function testWithoutEncapsulation(){
-        $this->assertEquals('test',clean_ccp_html('test'));
-        //also test that the other feature continue to work
-        $this->assertEquals('test',clean_ccp_html('<xyz>test</xyz>'));
+    public function testWithoutEncapsulation()
+    {
+        $this->assertEquals('test', clean_ccp_html('test'));
+        // also test that the other feature continue to work
+        $this->assertEquals('test', clean_ccp_html('<xyz>test</xyz>'));
     }
 
-    public function testEscapedUnicodeDecoding(){
-        $this->assertEquals('&#21019; &auml; &#128512;',clean_ccp_html('\u521b ä 😀'));
+    public function testEscapedUnicodeDecoding()
+    {
+        $this->assertEquals('&#21019; &auml; &#128512;', clean_ccp_html('\u521b ä 😀'));
     }
 }

--- a/tests/CleanCCPHtml/CleanCCPHtmlTest.php
+++ b/tests/CleanCCPHtml/CleanCCPHtmlTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 class CleanCCPHtmlTest extends TestCase
 {
     public function testEncapsulationRemoval(){
-        $this->assertEquals('test',clean_ccp_html("u'test"));
+        $this->assertEquals('test',clean_ccp_html("u'test'"));
     }
 
     public function testWithoutEncapsulation(){


### PR DESCRIPTION
Fixes unicode in ccp richtext from corporation descriptions from this to this:

![](https://cdn.discordapp.com/attachments/821361546608508938/1138811745935298690/image.png)

![Bildschirmfoto 2023-08-13 um 21 43 27](https://github.com/eveseat/services/assets/60423027/ed5590b2-a793-48a5-aa59-9ed30389a2e7)

For more contexts see #support on discord. 

In general, I think `clean_ccp_html` could use an overhaul, because for example links, font sizes and colors are something we could translate aswell. 


