### PR TITLE
Start integrating recursivetree/seat-prices-core into the seat core

### DIFF
--- a/src/Contracts/HasTypeID.php
+++ b/src/Contracts/HasTypeID.php
@@ -3,7 +3,7 @@
 namespace Seat\Services\Contracts;
 
 /**
- * An interface to describe objects
+ * An interface to describe objects having a type id.
  */
 interface HasTypeID
 {

--- a/src/Contracts/HasTypeID.php
+++ b/src/Contracts/HasTypeID.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Services\Contracts;
 
 /**

--- a/src/Contracts/HasTypeID.php
+++ b/src/Contracts/HasTypeID.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Seat\Services\Contracts;
+
+/**
+ * An interface to describe objects
+ */
+interface HasTypeID
+{
+    /**
+     * @return int The eve type id of this object
+     */
+    public function getTypeID(): int;
+}

--- a/src/Contracts/IPriceable.php
+++ b/src/Contracts/IPriceable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Seat\Services\Contracts;
+
+interface IPriceable extends HasTypeID
+{
+    /**
+     * @return int The amount of items to be appraised by a price provider
+     */
+    public function getAmount(): int;
+
+    /**
+     * Set the price of this object
+     * @param float $price
+     * @return void
+     */
+    public function setPrice(float $price): void;
+}

--- a/src/Contracts/IPriceable.php
+++ b/src/Contracts/IPriceable.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Services\Contracts;
 
 /**
@@ -15,8 +35,9 @@ interface IPriceable extends HasTypeID
     public function getAmount(): int;
 
     /**
-     * Set the price of this object
-     * @param float $price
+     * Set the price of this object.
+     *
+     * @param  float  $price
      * @return void
      */
     public function setPrice(float $price): void;

--- a/src/Contracts/IPriceable.php
+++ b/src/Contracts/IPriceable.php
@@ -2,6 +2,11 @@
 
 namespace Seat\Services\Contracts;
 
+/**
+ * Describes items that are appraisable using recursivetree/seat-prices-core.
+ * This interface is in the services package to encourage making classes that describe items compatible across both the
+ * seat core and plugin, even if they don't depend on recursivetree/seat-prices-core.
+ */
 interface IPriceable extends HasTypeID
 {
     /**

--- a/src/Helpers/UserAgentBuilder.php
+++ b/src/Helpers/UserAgentBuilder.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Services\Helpers;
 
 use Composer\InstalledVersions;
@@ -9,7 +29,7 @@ use Seat\Services\Exceptions\SettingException;
 
 /**
  * A helper to build user agents for seat packages
- * Structure and terms according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+ * Structure and terms according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent.
  */
 class UserAgentBuilder
 {
@@ -18,8 +38,9 @@ class UserAgentBuilder
     protected array $comments = [];
 
     /**
-     * Set the product part of the user agent
-     * @param string $product The new product name
+     * Set the product part of the user agent.
+     *
+     * @param  string  $product  The new product name
      * @return $this
      */
     public function product(string $product): UserAgentBuilder {
@@ -29,8 +50,9 @@ class UserAgentBuilder
     }
 
     /**
-     * Set the version of the product
-     * @param string $version
+     * Set the version of the product.
+     *
+     * @param  string  $version
      * @return $this
      */
     public function version(string $version): UserAgentBuilder {
@@ -40,8 +62,9 @@ class UserAgentBuilder
     }
 
     /**
-     * Configures the product and version of the user agent for a seat plugin
-     * @param string|AbstractSeatPlugin $plugin A plugin service provider instance or the FCQN of the service provider (e.g. MyServiceProvider::class)
+     * Configures the product and version of the user agent for a seat plugin.
+     *
+     * @param  string|AbstractSeatPlugin  $plugin  A plugin service provider instance or the FCQN of the service provider (e.g. MyServiceProvider::class)
      * @return $this
      */
     public function seatPlugin(string|AbstractSeatPlugin $plugin): UserAgentBuilder {
@@ -55,21 +78,23 @@ class UserAgentBuilder
     }
 
     /**
-     * Configures the product and version of the user agent for a packagist package
-     * @param string $vendor The packagist vendor name
-     * @param string $package The packagist package name
+     * Configures the product and version of the user agent for a packagist package.
+     *
+     * @param  string  $vendor  The packagist vendor name
+     * @param  string  $package  The packagist package name
      * @return $this
      */
     public function packagist(string $vendor, string $package): UserAgentBuilder {
-        $this->product = sprintf('%s:%s',$vendor, $package);
+        $this->product = sprintf('%s:%s', $vendor, $package);
         $this->version = $this->getPackageVersion($vendor, $package);
 
         return $this;
     }
 
     /**
-     * Adds a comment containing the product and version of the user agent for a seat plugin
-     * @param string|AbstractSeatPlugin $plugin A plugin service provider instance or the FCQN of the service provider (e.g. MyServiceProvider::class)
+     * Adds a comment containing the product and version of the user agent for a seat plugin.
+     *
+     * @param  string|AbstractSeatPlugin  $plugin  A plugin service provider instance or the FCQN of the service provider (e.g. MyServiceProvider::class)
      * @return $this
      */
     public function commentSeatPlugin(string|AbstractSeatPlugin $plugin): UserAgentBuilder {
@@ -83,20 +108,22 @@ class UserAgentBuilder
     }
 
     /**
-     * Adds a comment containing the product and version of the user agent for a packagist package
-     * @param string $vendor The packagist vendor name
-     * @param string $package The packagist package name
+     * Adds a comment containing the product and version of the user agent for a packagist package.
+     *
+     * @param  string  $vendor  The packagist vendor name
+     * @param  string  $package  The packagist package name
      * @return $this
      */
     public function commentPackagist(string $vendor, string $package): UserAgentBuilder {
-        $this->comment(sprintf('%s:%s/%s',$vendor, $package, $this->getPackageVersion($vendor, $package)));
+        $this->comment(sprintf('%s:%s/%s', $vendor, $package, $this->getPackageVersion($vendor, $package)));
 
         return $this;
     }
 
     /**
-     * Add a comment to the user agent
-     * @param string $comment the comment
+     * Add a comment to the user agent.
+     *
+     * @param  string  $comment  the comment
      * @return $this
      */
     public function comment(string $comment): UserAgentBuilder {
@@ -107,33 +134,39 @@ class UserAgentBuilder
 
     /**
      * Adds a reasonable set of default comments for any seat plugin.
+     *
      * @return $this
+     *
      * @throws SettingException
      */
     public function defaultComments(): UserAgentBuilder {
         $this->comment(sprintf('(admin contact: %s)', setting('admin_contact', true) ?? 'not specified'));
         $this->comment('(https://github.com/eveseat/seat)');
-        $this->commentPackagist('eveseat','seat');
-        $this->commentPackagist('eveseat','web');
-        $this->commentPackagist('eveseat','eveapi');
+        $this->commentPackagist('eveseat', 'seat');
+        $this->commentPackagist('eveseat', 'web');
+        $this->commentPackagist('eveseat', 'eveapi');
+
         return $this;
     }
 
     /**
-     * Assembles the user agent form its product, version, and comments into a string
+     * Assembles the user agent form its product, version, and comments into a string.
+     *
      * @return string The user agent
      */
     public function build(): string {
-        if($this->product === null || $this->version===null) {
+        if($this->product === null || $this->version === null) {
             throw new \Error('version or product not set.');
         }
-        return sprintf('%s/%s %s', $this->product, $this->version, implode(' ',$this->comments));
+
+        return sprintf('%s/%s %s', $this->product, $this->version, implode(' ', $this->comments));
     }
 
     /**
-     * Gets the installed version of a packagist package
-     * @param string $vendor The packagist vendor name
-     * @param string $package The packagist package name
+     * Gets the installed version of a packagist package.
+     *
+     * @param  string  $vendor  The packagist vendor name
+     * @param  string  $package  The packagist package name
      * @return string
      */
     private function getPackageVersion(string $vendor, string $package): string {

--- a/src/Helpers/UserAgentBuilder.php
+++ b/src/Helpers/UserAgentBuilder.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Seat\Services\Helpers;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+use Seat\Services\AbstractSeatPlugin;
+
+class UserAgentBuilder
+{
+    protected ?string $product = null;
+    protected ?string $version = null;
+    protected array $comments = [];
+
+    public function product(string $product): UserAgentBuilder {
+        $this->product = $product;
+
+        return $this;
+    }
+
+    public function version(string $version): UserAgentBuilder {
+        $this->version = $version;
+
+        return $this;
+    }
+
+
+    public function seatPlugin(string|AbstractSeatPlugin $plugin): UserAgentBuilder {
+        if(is_string($plugin)){
+            $plugin = new $plugin(null);
+        }
+
+        $this->packagist($plugin->getPackagistVendorName(), $plugin->getPackagistPackageName());
+
+        return $this;
+    }
+
+    public function packagist(string $vendor, string $package): UserAgentBuilder {
+        $this->product = sprintf('%s:%s',$vendor, $package);
+        $this->version = $this->getPackageVersion($vendor, $package);
+
+        return $this;
+    }
+
+    public function commentSeatPlugin(string|AbstractSeatPlugin $plugin): UserAgentBuilder {
+        if(is_string($plugin)){
+            $plugin = new $plugin(null);
+        }
+
+        $this->commentPackagist($plugin->getPackagistVendorName(), $plugin->getPackagistPackageName());
+
+        return $this;
+    }
+
+    public function commentPackagist(string $vendor, string $package): UserAgentBuilder {
+        $this->comment(sprintf('%s:%s/%s',$vendor, $package, $this->getPackageVersion($vendor, $package)));
+
+        return $this;
+    }
+
+    public function comment(string $part): UserAgentBuilder {
+        $this->comments[] = $part;
+
+        return $this;
+    }
+
+    public function defaultComments(): UserAgentBuilder {
+        $this->comment(sprintf('(admin contact: %s)', setting('admin_contact', true) ?? 'not specified'));
+        $this->comment('(https://github.com/eveseat/seat)');
+        $this->commentPackagist('eveseat','seat');
+        $this->commentPackagist('eveseat','web');
+        $this->commentPackagist('eveseat','eveapi');
+        return $this;
+    }
+
+    public function build(): string {
+        if($this->product === null || $this->version===null) {
+            throw new \Error('version or product not set.');
+        }
+        return sprintf('%s/%s %s', $this->product, $this->version, implode(' ',$this->comments));
+    }
+
+    private function getPackageVersion(string $vendor, string $package): string {
+        try {
+            return InstalledVersions::getPrettyVersion(sprintf('%s/%s', $vendor, $package)) ?? 'unknown';
+        } catch (OutOfBoundsException $e) {
+            return 'unknown';
+        }
+    }
+}

--- a/src/Helpers/UserAgentBuilder.php
+++ b/src/Helpers/UserAgentBuilder.php
@@ -5,26 +5,45 @@ namespace Seat\Services\Helpers;
 use Composer\InstalledVersions;
 use OutOfBoundsException;
 use Seat\Services\AbstractSeatPlugin;
+use Seat\Services\Exceptions\SettingException;
 
+/**
+ * A helper to build user agents for seat packages
+ * Structure and terms according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+ */
 class UserAgentBuilder
 {
     protected ?string $product = null;
     protected ?string $version = null;
     protected array $comments = [];
 
+    /**
+     * Set the product part of the user agent
+     * @param string $product The new product name
+     * @return $this
+     */
     public function product(string $product): UserAgentBuilder {
         $this->product = $product;
 
         return $this;
     }
 
+    /**
+     * Set the version of the product
+     * @param string $version
+     * @return $this
+     */
     public function version(string $version): UserAgentBuilder {
         $this->version = $version;
 
         return $this;
     }
 
-
+    /**
+     * Configures the product and version of the user agent for a seat plugin
+     * @param string|AbstractSeatPlugin $plugin A plugin service provider instance or the FCQN of the service provider (e.g. MyServiceProvider::class)
+     * @return $this
+     */
     public function seatPlugin(string|AbstractSeatPlugin $plugin): UserAgentBuilder {
         if(is_string($plugin)){
             $plugin = new $plugin(null);
@@ -35,6 +54,12 @@ class UserAgentBuilder
         return $this;
     }
 
+    /**
+     * Configures the product and version of the user agent for a packagist package
+     * @param string $vendor The packagist vendor name
+     * @param string $package The packagist package name
+     * @return $this
+     */
     public function packagist(string $vendor, string $package): UserAgentBuilder {
         $this->product = sprintf('%s:%s',$vendor, $package);
         $this->version = $this->getPackageVersion($vendor, $package);
@@ -42,6 +67,11 @@ class UserAgentBuilder
         return $this;
     }
 
+    /**
+     * Adds a comment containing the product and version of the user agent for a seat plugin
+     * @param string|AbstractSeatPlugin $plugin A plugin service provider instance or the FCQN of the service provider (e.g. MyServiceProvider::class)
+     * @return $this
+     */
     public function commentSeatPlugin(string|AbstractSeatPlugin $plugin): UserAgentBuilder {
         if(is_string($plugin)){
             $plugin = new $plugin(null);
@@ -52,18 +82,34 @@ class UserAgentBuilder
         return $this;
     }
 
+    /**
+     * Adds a comment containing the product and version of the user agent for a packagist package
+     * @param string $vendor The packagist vendor name
+     * @param string $package The packagist package name
+     * @return $this
+     */
     public function commentPackagist(string $vendor, string $package): UserAgentBuilder {
         $this->comment(sprintf('%s:%s/%s',$vendor, $package, $this->getPackageVersion($vendor, $package)));
 
         return $this;
     }
 
-    public function comment(string $part): UserAgentBuilder {
-        $this->comments[] = $part;
+    /**
+     * Add a comment to the user agent
+     * @param string $comment the comment
+     * @return $this
+     */
+    public function comment(string $comment): UserAgentBuilder {
+        $this->comments[] = $comment;
 
         return $this;
     }
 
+    /**
+     * Adds a reasonable set of default comments for any seat plugin.
+     * @return $this
+     * @throws SettingException
+     */
     public function defaultComments(): UserAgentBuilder {
         $this->comment(sprintf('(admin contact: %s)', setting('admin_contact', true) ?? 'not specified'));
         $this->comment('(https://github.com/eveseat/seat)');
@@ -73,6 +119,10 @@ class UserAgentBuilder
         return $this;
     }
 
+    /**
+     * Assembles the user agent form its product, version, and comments into a string
+     * @return string The user agent
+     */
     public function build(): string {
         if($this->product === null || $this->version===null) {
             throw new \Error('version or product not set.');
@@ -80,6 +130,12 @@ class UserAgentBuilder
         return sprintf('%s/%s %s', $this->product, $this->version, implode(' ',$this->comments));
     }
 
+    /**
+     * Gets the installed version of a packagist package
+     * @param string $vendor The packagist vendor name
+     * @param string $package The packagist package name
+     * @return string
+     */
     private function getPackageVersion(string $vendor, string $package): string {
         try {
             return InstalledVersions::getPrettyVersion(sprintf('%s/%s', $vendor, $package)) ?? 'unknown';

--- a/src/Items/EveType.php
+++ b/src/Items/EveType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Seat\Services\Items;
+
+
+use Seat\Services\Contracts\HasTypeID;
+
+class EveType implements HasTypeID
+{
+    protected int $type_id;
+
+    /**
+     * @param int|HasTypeID $type_id
+     */
+    public function __construct(int | HasTypeID $type_id)
+    {
+        if($type_id instanceof HasTypeID){
+            $type_id = $type_id->getTypeID();
+        }
+
+        $this->type_id = $type_id;
+    }
+
+
+    public function getTypeID(): int
+    {
+        return $this->type_id;
+    }
+}

--- a/src/Items/EveType.php
+++ b/src/Items/EveType.php
@@ -5,6 +5,9 @@ namespace Seat\Services\Items;
 
 use Seat\Services\Contracts\HasTypeID;
 
+/**
+ * A basic implementation of HasTypeID
+ */
 class EveType implements HasTypeID
 {
     protected int $type_id;
@@ -21,7 +24,9 @@ class EveType implements HasTypeID
         $this->type_id = $type_id;
     }
 
-
+    /**
+     * @return int The type id
+     */
     public function getTypeID(): int
     {
         return $this->type_id;

--- a/src/Items/EveType.php
+++ b/src/Items/EveType.php
@@ -1,21 +1,40 @@
 <?php
 
-namespace Seat\Services\Items;
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
+namespace Seat\Services\Items;
 
 use Seat\Services\Contracts\HasTypeID;
 
 /**
- * A basic implementation of HasTypeID
+ * A basic implementation of HasTypeID.
  */
 class EveType implements HasTypeID
 {
     protected int $type_id;
 
     /**
-     * @param int|HasTypeID $type_id
+     * @param  int|HasTypeID  $type_id
      */
-    public function __construct(int | HasTypeID $type_id)
+    public function __construct(int|HasTypeID $type_id)
     {
         if($type_id instanceof HasTypeID){
             $type_id = $type_id->getTypeID();

--- a/src/Items/PriceableEveType.php
+++ b/src/Items/PriceableEveType.php
@@ -1,12 +1,32 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Services\Items;
 
 use Seat\Services\Contracts\HasTypeID;
 use Seat\Services\Contracts\IPriceable;
 
 /**
- * A basic implementation od IPriceable
+ * A basic implementation od IPriceable.
  */
 class PriceableEveType extends EveType implements IPriceable
 {
@@ -14,8 +34,8 @@ class PriceableEveType extends EveType implements IPriceable
     protected float $amount;
 
     /**
-     * @param int|HasTypeID $type_id The eve type to be appraised
-     * @param float $amount The amount of this type to be appraised
+     * @param  int|HasTypeID  $type_id  The eve type to be appraised
+     * @param  float  $amount  The amount of this type to be appraised
      */
     public function __construct(int|HasTypeID $type_id, float $amount)
     {
@@ -41,7 +61,7 @@ class PriceableEveType extends EveType implements IPriceable
     }
 
     /**
-     * @param float $price The new price of this item stack
+     * @param  float  $price  The new price of this item stack
      * @return void
      */
     public function setPrice(float $price): void

--- a/src/Items/PriceableEveType.php
+++ b/src/Items/PriceableEveType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Seat\Services\Items;
+
+use Seat\Services\Contracts\HasTypeID;
+use Seat\Services\Contracts\IPriceable;
+
+class PriceableEveType extends EveType implements IPriceable
+{
+    protected float $price;
+    protected float $amount;
+
+    /**
+     * @param int|HasTypeID $type_id
+     * @param float $amount
+     */
+    public function __construct(int|HasTypeID $type_id, float $amount)
+    {
+        parent::__construct($type_id);
+        $this->price = 0;
+        $this->amount = $amount;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPrice(): float
+    {
+        return $this->price;
+    }
+
+    public function setPrice(float $price): void
+    {
+       $this->price = $price;
+    }
+}

--- a/src/Items/PriceableEveType.php
+++ b/src/Items/PriceableEveType.php
@@ -5,14 +5,17 @@ namespace Seat\Services\Items;
 use Seat\Services\Contracts\HasTypeID;
 use Seat\Services\Contracts\IPriceable;
 
+/**
+ * A basic implementation od IPriceable
+ */
 class PriceableEveType extends EveType implements IPriceable
 {
     protected float $price;
     protected float $amount;
 
     /**
-     * @param int|HasTypeID $type_id
-     * @param float $amount
+     * @param int|HasTypeID $type_id The eve type to be appraised
+     * @param float $amount The amount of this type to be appraised
      */
     public function __construct(int|HasTypeID $type_id, float $amount)
     {
@@ -21,19 +24,26 @@ class PriceableEveType extends EveType implements IPriceable
         $this->amount = $amount;
     }
 
+    /**
+     * @return int The amount of this item to be appraised
+     */
     public function getAmount(): int
     {
         return $this->amount;
     }
 
     /**
-     * @return float
+     * @return float The price of this item stack
      */
     public function getPrice(): float
     {
         return $this->price;
     }
 
+    /**
+     * @param float $price The new price of this item stack
+     * @return void
+     */
     public function setPrice(float $price): void
     {
        $this->price = $price;


### PR DESCRIPTION
## Background
* https://github.com/eveseat/seat/discussions/892
* https://github.com/recursivetree/seat-prices-core/tree/master

After the evepraisal shutdown, crytpa and I started working on a new system for seat plugins to get prices of eve items. For accelerated development, we decided to at the beginning not include it in the core, but with a long-term goal to move the full plugin or parts over to the seat core.

This PR is the first step in this migration process. While seat-prices-core isn't completely finished yet, it is far enough to be usable. Additionally, there are parts of the plugin that are already quite stable and unlikely to change going forward. Only these stable parts are being moved over.

## HasTypeID interface
This interface describes any object that's associated with a type id. Most notably, this is the InvType model, but other models like assets could have it implemented too. The reason it exists is easy transformations between different formats of items. For example, you might want to appraise InvTypes or CharacterAssets using a `appraise($items)` function. Without a common type id interface, you'd need to convert it to an appropriate input format for `appraise` differently each time you use a different item data source. The following example further illustrates this:
```php
$items = get_items();
$items = $items->map(function($item){return $item->toCorrectFormat()});
appraise($items);
```
is much worse than
```php
$items = get_items();
appraise($items);
```
The reason this interface has to be in the core is that it's only useful if every item-like class implements it, otherwise you still need to manually cast them. If it resides in seat-prices-core, it is not possible for it to be implemented on `InvType` in eveapi since eveapi should not have a dependency on seat-prices-core. 

A similar situation is with treelib: It doesn't directly use seat-prices-core and therefore doesn't depend on it, but it provides a few classes that could benefit from implementing `HasTypeID`.

## IPriceable
This class is a bit more specific to seat-prices-core, but I included it for the same reasons as `HasTypeID`: To increase interoperability between different packages(plugin and core).

## EveType and PriceableEveType
These are two boring implementations of `HasTypeID` and `IPriceable` so that packages don't need to roll their own implementations.

## UserAgentBuilder
I noticed that many price providers need to make API requests to services like evepraisal or evemarketer. These requests all require a user agent. For some reason I decided to go completely over board and overengineer a user agent builder. It is included in this first PR since it might also benefit other plugins.
