### PR TITLE
fix: update iss check to allow for ccp change.

### DIFF
--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -166,7 +166,7 @@ class Provider extends AbstractProvider
         $jws = Load::jws($access_token)
             ->algs(['RS256', 'ES256', 'HS256'])
             ->exp()
-            ->iss('login.eveonline.com')
+            // ->iss('login.eveonline.com') // Disabled temporarily to account for CCP iss change. SeAT v5 will re-enable with proper handling.
             ->header('typ', new TypeChecker(['JWT'], true))
             ->claim('scp', new ScpChecker($scopes))
             ->claim('sub', new SubEveCharacterChecker())

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -166,7 +166,7 @@ class Provider extends AbstractProvider
         $jws = Load::jws($access_token)
             ->algs(['RS256', 'ES256', 'HS256'])
             ->exp()
-            // ->iss('login.eveonline.com') // Disabled temporarily to account for CCP iss change. SeAT v5 will re-enable with proper handling.
+            ->claim('iss', new \Jose\Component\Checker\IssuerChecker(['https://login.eveonline.com', 'login.eveonline.com'], true))
             ->header('typ', new TypeChecker(['JWT'], true))
             ->claim('scp', new ScpChecker($scopes))
             ->claim('sub', new SubEveCharacterChecker())

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
https://forums.eveonline.com/t/eve-sso-jwt-token-update-on-31-october-11-00-utc/424277

As the current method does not allow both iss claims to be valid, remove it until reimplemented in SeAT v5.