### PR TITLE
Deferred migrations system

### DIFF
--- a/src/Facades/DeferredMigration.php
+++ b/src/Facades/DeferredMigration.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Seat\Services\Facades;
+
+use Closure;
+use Illuminate\Support\Facades\Facade;
+use Seat\Services\Services\DeferredMigrationRegistry;
+
+/**
+ * @method static void schedule(Closure $migration)
+ */
+class DeferredMigration extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return DeferredMigrationRegistry::class;
+    }
+}

--- a/src/Listeners/RunDeferredMigrations.php
+++ b/src/Listeners/RunDeferredMigrations.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Seat\Services\Listeners;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Events\MigrationsEnded;
+use Seat\Services\Services\DeferredMigrationRegistry;
+
+class RunDeferredMigrations
+{
+    /**
+     * @throws BindingResolutionException
+     */
+    public function handle(MigrationsEnded $event) {
+        $registry = app()->make(DeferredMigrationRegistry::class);
+
+        $registry->runMigrations();
+    }
+}

--- a/src/Services/DeferredMigrationRegistry.php
+++ b/src/Services/DeferredMigrationRegistry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Seat\Services\Services;
+
+use Closure;
+
+class DeferredMigrationRegistry
+{
+    /**
+     * @var array<Closure>
+     */
+    protected array $deferred_migrations = [];
+
+    public function schedule(Closure $migration): void {
+        $this->deferred_migrations[] = $migration;
+    }
+
+    public function runMigrations(): void {
+        logger()->info(sprintf("[Deferred Migrations] Running %d deferred migrations", count($this->deferred_migrations)));
+
+        foreach ($this->deferred_migrations as $migration){
+            $migration();
+        }
+    }
+}


### PR DESCRIPTION
While working on a squad system update, I found a migration that depends on the business logic: https://github.com/eveseat/web/blob/fe45844ab67e68761720ce536d0ce481b4ff0f39/src/database/migrations/2020_12_06_220254_upgrade_squads_maj4_min4_hf2.php

This is a bad idea, since when the data the business logic operates on changes, the migrations breaks since the migration updating the data for the business logic didn't run yet. However, this migration is there to remove a broken state, so not running it is not an option.

The solution that this PR enables are deferred migrations: A migration can schedule a closure that should be run after all other migrations have completed. This means the data is already migrated to a state where the business logic is guaranteed to be able process it.

In a migration, using `DeferredMigration::schedule`, a migration can schedule a deferred migration:

```php
public function up() {
   DeferredMigration::schedule(function(){
       //runs after all other migrations
   });
}
```