### PR TITLE
Fix socialite provider

### DIFF
--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider
     /**
      * Get the authentication URL for the provider.
      *
-     * @param string $state
+     * @param  string  $state
      * @return string
      */
     protected function getAuthUrl($state)
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
     /**
      * Get the raw user for the given access token.
      *
-     * @param string $token
+     * @param  string  $token
      * @return array
      */
     protected function getUserByToken($token)
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
     /**
      * Map the raw user array to a Socialite User instance.
      *
-     * @param array $user
+     * @param  array  $user
      * @return \Laravel\Socialite\Two\User
      */
     protected function mapUserToObject(array $user)
@@ -107,7 +107,7 @@ class Provider extends AbstractProvider
     /**
      * Get the POST fields for the token request.
      *
-     * @param string $code
+     * @param  string  $code
      * @return array
      */
     protected function getTokenFields($code)
@@ -127,7 +127,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * @param string $access_token
+     * @param  string  $access_token
      * @return array
      *
      * @throws \Exception

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -117,6 +117,7 @@ class Provider extends AbstractProvider
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
         ];
+
         
         if ($this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider
     /**
      * Get the authentication URL for the provider.
      *
-     * @param  string  $state
+     * @param string $state
      * @return string
      */
     protected function getAuthUrl($state)
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
     /**
      * Get the raw user for the given access token.
      *
-     * @param  string  $token
+     * @param string $token
      * @return array
      */
     protected function getUserByToken($token)
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
     /**
      * Map the raw user array to a Socialite User instance.
      *
-     * @param  array  $user
+     * @param array $user
      * @return \Laravel\Socialite\Two\User
      */
     protected function mapUserToObject(array $user)
@@ -94,20 +94,20 @@ class Provider extends AbstractProvider
         }
 
         return (new User)->setRaw($user)->map([
-            'id'                   => $character_id,
-            'name'                 => $user['name'],
-            'nickname'             => $user['name'],
+            'id' => $character_id,
+            'name' => $user['name'],
+            'nickname' => $user['name'],
             'character_owner_hash' => $user['owner'],
-            'scopes'               => is_array($user['scp']) ? $user['scp'] : [$user['scp']],
-            'expires_on'           => $user['exp'],
-            'avatar'               => $avatar,
+            'scopes' => is_array($user['scp']) ? $user['scp'] : [$user['scp']],
+            'expires_on' => $user['exp'],
+            'avatar' => $avatar,
         ]);
     }
 
     /**
      * Get the POST fields for the token request.
      *
-     * @param  string  $code
+     * @param string $code
      * @return array
      */
     protected function getTokenFields($code)
@@ -115,7 +115,7 @@ class Provider extends AbstractProvider
         $fields = [
             'grant_type' => 'authorization_code',
             'code' => $code,
-            'redirect_uri' => $this->redirectUrl
+            'redirect_uri' => $this->redirectUrl,
         ];
 
 
@@ -127,7 +127,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * @param  string  $access_token
+     * @param string $access_token
      * @return array
      *
      * @throws \Exception

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -118,7 +118,6 @@ class Provider extends AbstractProvider
             'redirect_uri' => $this->redirectUrl,
         ];
 
-        
         if ($this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
         }

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -112,7 +112,18 @@ class Provider extends AbstractProvider
      */
     protected function getTokenFields($code)
     {
-        return array_merge(parent::getTokenFields($code), ['grant_type' => 'authorization_code']);
+        $fields = [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $this->redirectUrl
+        ];
+
+
+        if ($this->usesPKCE()) {
+            $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
+        }
+
+        return $fields;
     }
 
     /**

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -117,8 +117,7 @@ class Provider extends AbstractProvider
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
         ];
-
-
+        
         if ($this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
         }


### PR DESCRIPTION
Latest version of Socialite (https://github.com/laravel/socialite/releases/tag/v5.12.0) added a breaking bug for EVE authentication with this PR : https://github.com/laravel/socialite/pull/684

The fix is to change the list of fields sent in the form body to the token endpoint to no longer include client_id and client_secret because they are provided in the Authorization header. This is the "correct" way to provide client_id/client_secret to an OAuth endpoint (that was the point of the PR on socialite in the first place). So the fix I propose is to accept this behavior and only remove the unecessary fields from the form body.

The Original SeAT error was :

```
Client error: `POST https://login.eveonline.com/v2/oauth/token` resulted in a `400 Bad Request` response:
{"error":"invalid_request","error_description":"Client credentials should only be provided once. Remove them from either (truncated...)
```

meaning the client_id/client_secret combo should be in the Authorization header OR the form body, but not both.