### PR TITLE
Fix the socialite provider after they pushed a revert

### DIFF
--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider
     /**
      * Get the authentication URL for the provider.
      *
-     * @param string $state
+     * @param  string  $state
      * @return string
      */
     protected function getAuthUrl($state)
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
     /**
      * Get the raw user for the given access token.
      *
-     * @param string $token
+     * @param  string  $token
      * @return array
      */
     protected function getUserByToken($token)
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
     /**
      * Map the raw user array to a Socialite User instance.
      *
-     * @param array $user
+     * @param  array  $user
      * @return \Laravel\Socialite\Two\User
      */
     protected function mapUserToObject(array $user)
@@ -107,7 +107,7 @@ class Provider extends AbstractProvider
     /**
      * Get the POST fields for the token request.
      *
-     * @param string $code
+     * @param  string  $code
      * @return array
      */
     protected function getTokenFields($code)
@@ -127,7 +127,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * @param string $access_token
+     * @param  string  $access_token
      * @return array
      *
      * @throws \Exception

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -140,4 +140,15 @@ class Provider extends AbstractProvider
 
         return $validator->validateToken(config('eseye.esi.auth.client_id'), $access_token);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getTokenHeaders($code)
+    {
+        return [
+            'Accept' => 'application/json',
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret),
+        ];
+    }
 }

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -117,6 +117,7 @@ class Provider extends AbstractProvider
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
         ];
+
         
         if ($this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of SeAT
  *
- * Copyright (C) 2015 to 2022 Leon Jacobs
+ * Copyright (C) 2015 to present Leon Jacobs
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider
     /**
      * Get the authentication URL for the provider.
      *
-     * @param  string  $state
+     * @param string $state
      * @return string
      */
     protected function getAuthUrl($state)
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
     /**
      * Get the raw user for the given access token.
      *
-     * @param  string  $token
+     * @param string $token
      * @return array
      */
     protected function getUserByToken($token)
@@ -79,7 +79,7 @@ class Provider extends AbstractProvider
     /**
      * Map the raw user array to a Socialite User instance.
      *
-     * @param  array  $user
+     * @param array $user
      * @return \Laravel\Socialite\Two\User
      */
     protected function mapUserToObject(array $user)
@@ -94,20 +94,20 @@ class Provider extends AbstractProvider
         }
 
         return (new User)->setRaw($user)->map([
-            'id'                   => $character_id,
-            'name'                 => $user['name'],
-            'nickname'             => $user['name'],
+            'id' => $character_id,
+            'name' => $user['name'],
+            'nickname' => $user['name'],
             'character_owner_hash' => $user['owner'],
-            'scopes'               => is_array($user['scp']) ? $user['scp'] : [$user['scp']],
-            'expires_on'           => $user['exp'],
-            'avatar'               => $avatar,
+            'scopes' => is_array($user['scp']) ? $user['scp'] : [$user['scp']],
+            'expires_on' => $user['exp'],
+            'avatar' => $avatar,
         ]);
     }
 
     /**
      * Get the POST fields for the token request.
      *
-     * @param  string  $code
+     * @param string $code
      * @return array
      */
     protected function getTokenFields($code)
@@ -115,7 +115,7 @@ class Provider extends AbstractProvider
         $fields = [
             'grant_type' => 'authorization_code',
             'code' => $code,
-            'redirect_uri' => $this->redirectUrl
+            'redirect_uri' => $this->redirectUrl,
         ];
 
 
@@ -127,7 +127,7 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * @param  string  $access_token
+     * @param string $access_token
      * @return array
      *
      * @throws \Exception

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -118,7 +118,6 @@ class Provider extends AbstractProvider
             'redirect_uri' => $this->redirectUrl,
         ];
 
-        
         if ($this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
         }

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -112,7 +112,18 @@ class Provider extends AbstractProvider
      */
     protected function getTokenFields($code)
     {
-        return array_merge(parent::getTokenFields($code), ['grant_type' => 'authorization_code']);
+        $fields = [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $this->redirectUrl
+        ];
+
+
+        if ($this->usesPKCE()) {
+            $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
+        }
+
+        return $fields;
     }
 
     /**

--- a/src/Socialite/EveOnline/Provider.php
+++ b/src/Socialite/EveOnline/Provider.php
@@ -117,8 +117,7 @@ class Provider extends AbstractProvider
             'code' => $code,
             'redirect_uri' => $this->redirectUrl,
         ];
-
-
+        
         if ($this->usesPKCE()) {
             $fields['code_verifier'] = $this->request->session()->pull('code_verifier');
         }


### PR DESCRIPTION
less than an hour ago the Socialite repository maintainers have reverted their previous PR that created a breaking change on how authentication is handled to the token endpoint. This broke the previous PR I did to fix the 500 error on our side. Now we have a 401 error because the Authentication header is missing.

I created an issue on their repo yesterday about the breaking change, they dismissed it saying they did not maintain our provider (no shit) and closed the issue (so I created the PR here to fix the issue because they would'nt fix it on their repo) and the next day another guy says he has an issue and suddenly the change is reverted... Blows my mind.

Anyway, I tested this one on my local docker env and it works. I basically reimplemented their previous change because it is more in line with the OAuth RFC to use the auth header to send clientId/clientSecret.