### PR TITLE
feat: add HasTypeIDWithAmount interface

### DIFF
--- a/src/Contracts/HasTypeIDWithAmount.php
+++ b/src/Contracts/HasTypeIDWithAmount.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Seat\Services\Contracts;
+
+/**
+ * This interface is something between HasTypeID and IPriceable for things that have an amount and type but no price, like an asset list.
+ * The goal is to improve cross-plugin item handling compatibility.
+ */
+interface HasTypeIDWithAmount extends HasTypeID
+{
+    /**
+     * @return int The amount of items
+     */
+    public function getAmount(): int;
+}

--- a/src/Contracts/HasTypeIDWithAmount.php
+++ b/src/Contracts/HasTypeIDWithAmount.php
@@ -1,5 +1,25 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Services\Contracts;
 
 /**

--- a/src/Contracts/IPriceable.php
+++ b/src/Contracts/IPriceable.php
@@ -27,13 +27,8 @@ namespace Seat\Services\Contracts;
  * This interface is in the services package to encourage making classes that describe items compatible across both the
  * seat core and plugin, even if they don't depend on recursivetree/seat-prices-core.
  */
-interface IPriceable extends HasTypeID
+interface IPriceable extends HasTypeID, HasTypeIDWithAmount
 {
-    /**
-     * @return int The amount of items to be appraised by a price provider
-     */
-    public function getAmount(): int;
-
     /**
      * Set the price of this object.
      *

--- a/src/Contracts/IPriceable.php
+++ b/src/Contracts/IPriceable.php
@@ -27,7 +27,7 @@ namespace Seat\Services\Contracts;
  * This interface is in the services package to encourage making classes that describe items compatible across both the
  * seat core and plugin, even if they don't depend on recursivetree/seat-prices-core.
  */
-interface IPriceable extends HasTypeID, HasTypeIDWithAmount
+interface IPriceable extends HasTypeIDWithAmount
 {
     /**
      * Set the price of this object.

--- a/src/Items/EveTypeWithAmount.php
+++ b/src/Items/EveTypeWithAmount.php
@@ -1,20 +1,40 @@
 <?php
 
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to present Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 namespace Seat\Services\Items;
 
 use Seat\Services\Contracts\HasTypeID;
 use Seat\Services\Contracts\HasTypeIDWithAmount;
 
 /**
- * A simple implementation on HasTypeIDWithAmount
+ * A simple implementation on HasTypeIDWithAmount.
  */
 class EveTypeWithAmount extends EveType implements HasTypeIDWithAmount
 {
     private int $amount;
 
     /**
-     * @param int|HasTypeID $type_id
-     * @param int $amount
+     * @param  int|HasTypeID  $type_id
+     * @param  int  $amount
      */
     public function __construct(int|HasTypeID $type_id, int $amount)
     {

--- a/src/Items/EveTypeWithAmount.php
+++ b/src/Items/EveTypeWithAmount.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seat\Services\Items;
+
+use Seat\Services\Contracts\HasTypeID;
+use Seat\Services\Contracts\HasTypeIDWithAmount;
+
+/**
+ * A simple implementation on HasTypeIDWithAmount
+ */
+class EveTypeWithAmount extends EveType implements HasTypeIDWithAmount
+{
+    private int $amount;
+
+    /**
+     * @param int|HasTypeID $type_id
+     * @param int $amount
+     */
+    public function __construct(int|HasTypeID $type_id, int $amount)
+    {
+        parent::__construct($type_id);
+        $this->amount = $amount;
+    }
+
+    /**
+     * @return int The amount of items
+     */
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+}

--- a/src/Items/PriceableEveType.php
+++ b/src/Items/PriceableEveType.php
@@ -23,33 +23,24 @@
 namespace Seat\Services\Items;
 
 use Seat\Services\Contracts\HasTypeID;
+use Seat\Services\Contracts\HasTypeIDWithAmount;
 use Seat\Services\Contracts\IPriceable;
 
 /**
  * A basic implementation od IPriceable.
  */
-class PriceableEveType extends EveType implements IPriceable
+class PriceableEveType extends EveTypeWithAmount implements IPriceable
 {
     protected float $price;
-    protected float $amount;
 
     /**
      * @param  int|HasTypeID  $type_id  The eve type to be appraised
-     * @param  float  $amount  The amount of this type to be appraised
+     * @param  float|int  $amount  The amount of this type to be appraised
      */
-    public function __construct(int|HasTypeID $type_id, float $amount)
+    public function __construct(int|HasTypeID $type_id, float|int $amount)
     {
-        parent::__construct($type_id);
+        parent::__construct($type_id, (int) $amount);
         $this->price = 0;
-        $this->amount = $amount;
-    }
-
-    /**
-     * @return int The amount of this item to be appraised
-     */
-    public function getAmount(): int
-    {
-        return $this->amount;
     }
 
     /**

--- a/src/Items/PriceableEveType.php
+++ b/src/Items/PriceableEveType.php
@@ -23,7 +23,6 @@
 namespace Seat\Services\Items;
 
 use Seat\Services\Contracts\HasTypeID;
-use Seat\Services\Contracts\HasTypeIDWithAmount;
 use Seat\Services\Contracts\IPriceable;
 
 /**


### PR DESCRIPTION
This PR adds a new interface between HasTypeID and IPriceable. The issue is that sometimes, you have a list of items with amount, like a asset list, that doesn't need the price side from IPriceable, but that could profit of the amount side of IPriceable.

I'm currently working on making seat-inventory compatible with the new item ecosystem around the prices plugin and would massively profit of this new interface.