### PR TITLE
fix: ccp_clean_html handle case if removing ccp styling results in empty string

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -144,6 +144,9 @@ if (! function_exists('clean_ccp_html')) {
         // or that is not considered valid HTML anyways.
         $html = strip_tags($html, $acceptable_tags);
 
+        // DOMDocument->loadHTML doesn't handle empty strings
+        if($html === '') return '';
+
         // Prep a DOMDocument so that we can remove font
         // colors and size attributes.
         $dom = new DOMDocument();


### PR DESCRIPTION
`ccp_clean_html` converts the messages of evemails into browser-presentable html. The function currently crashes if it is called with `u''` or a few other, specific messages. 

In the implementation, `DOMDocument->loadHTML` doesn't like empty strings. While we do have an empty string check at the top of the function, we apply transformations that can result in an empty string after the check, so it is possible that an empty string reaches `DOMDocument->loadHTML`.