### PR TITLE
Bye ESI versions, Hello compatibility date - services edition

### DIFF
--- a/src/Contracts/EsiClient.php
+++ b/src/Contracts/EsiClient.php
@@ -44,17 +44,6 @@ interface EsiClient
     public function isAuthenticated(): bool;
 
     /**
-     * @return string
-     */
-    public function getVersion(): string;
-
-    /**
-     * @param  string  $version
-     * @return $this
-     */
-    public function setVersion(string $version): self;
-
-    /**
      * @return array
      */
     public function getQueryString(): array;

--- a/src/Contracts/EsiClient.php
+++ b/src/Contracts/EsiClient.php
@@ -55,7 +55,7 @@ interface EsiClient
     public function setQueryString(array $query): self;
 
     /**
-     * @param string $date
+     * @param  string  $date
      * @return void
      */
     public function setCompatibilityDate(string $date): self;

--- a/src/Contracts/EsiClient.php
+++ b/src/Contracts/EsiClient.php
@@ -58,7 +58,7 @@ interface EsiClient
      * @param string $date
      * @return void
      */
-    public function setCompatibilityDate(string $date): void;
+    public function setCompatibilityDate(string $date): self;
 
     /**
      * @return string

--- a/src/Contracts/EsiClient.php
+++ b/src/Contracts/EsiClient.php
@@ -55,6 +55,17 @@ interface EsiClient
     public function setQueryString(array $query): self;
 
     /**
+     * @param string $date
+     * @return void
+     */
+    public function setCompatibilityDate(string $date): void;
+
+    /**
+     * @return string
+     */
+    public function getCompatibilityDate(): string;
+
+    /**
      * @return array
      */
     public function getBody(): array;


### PR DESCRIPTION
ESI no longer uses versions in the endpoint URL, and as of right now, they also have no effect. See https://developers.eveonline.com/blog/changing-versions-v42-was-getting-out-of-hand. Instead, there are now compatibility dates.

This PR removes endpoint versions from the EsiClient interface, but also introduces support for the compatibility date headers. This is a breaking change. However, I do think it is unavoidable because eveapi always operates on EsiClients and has no way of accessing the underlying Eseye instace. I don't think it is likely that there are any EsiClient implementations besides the eveapi one, so we are probably fine.

Must be released at the same time as https://github.com/eveseat/eveapi/pull/438